### PR TITLE
Return undefined when no point is found

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,32 +1,15 @@
 /**
+ * @typedef {import('unist').Point} Point
  * @typedef {import('vfile').VFile} VFile
  * @typedef {import('vfile').Value} Value
  */
 
 /**
- * @typedef Point
- *   unist point, where `line` and `column` can be `undefined`.
- * @property {number | undefined} line
- *   Line.
- * @property {number | undefined} column
- *   Column.
- * @property {number | undefined} [offset]
- *   Offset.
- *
- * @typedef PointLike
- *   unist point, allowed as input.
- * @property {number | null | undefined} [line]
- *   Line.
- * @property {number | null | undefined} [column]
- *   Column.
- * @property {number | null | undefined} [offset]
- *   Offset.
- *
  * @callback ToPoint
  *   Get a line/column-based `point` from `offset`.
  * @param {number | null | undefined} [offset]
  *   Something that should be an `offset.
- * @returns {Point}
+ * @returns {Point | undefined}
  *   Point, line/column are undefined for invalid or out of bounds input.
  *
  * @callback ToOffset
@@ -86,8 +69,6 @@ export function location(file) {
         }
       }
     }
-
-    return {line: undefined, column: undefined, offset: undefined}
   }
 
   /** @type {ToOffset} */

--- a/test.js
+++ b/test.js
@@ -44,6 +44,7 @@ test('toOffset(point)', function () {
   const place = location('foo\nbar\nbaz')
 
   assert.equal(
+    // @ts-expect-error We explicitly test invalid input.
     place.toOffset({line: undefined, column: undefined}),
     -1,
     'should return `-1` for invalid input'
@@ -79,13 +80,13 @@ test('toPoint(offset)', function () {
 
   assert.deepEqual(
     place.toPoint(-1),
-    {line: undefined, column: undefined, offset: undefined},
+    undefined,
     'should return an empty object for invalid input'
   )
 
   assert.deepEqual(
     place.toPoint(12),
-    {line: undefined, column: undefined, offset: undefined},
+    undefined,
     'should return an empty object for out of bounds input'
   )
 
@@ -107,11 +108,7 @@ test('other tests', function () {
 
   assert.deepEqual(
     [place.toPoint(3), place.toPoint(4), place.toPoint(5)],
-    [
-      {line: 1, column: 4, offset: 3},
-      {line: undefined, column: undefined, offset: undefined},
-      {line: undefined, column: undefined, offset: undefined}
-    ],
+    [{line: 1, column: 4, offset: 3}, undefined, undefined],
     'should return points for offsets around an EOF w/o EOLs'
   )
 
@@ -132,7 +129,7 @@ test('other tests', function () {
     [
       {line: 1, column: 4, offset: 3},
       {line: 2, column: 1, offset: 4},
-      {line: undefined, column: undefined, offset: undefined}
+      undefined
     ],
     'should return points for offsets around an EOF EOL'
   )


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`toPoint` now returns a valid unist `Point` or undefined. This means the internal `Point` type is no longer used. The `PointLike` type was already unused.

Closes #10

<!--do not edit: pr-->
